### PR TITLE
Corrige inicialização da janela principal com CustomTkinter

### DIFF
--- a/desktop_app.py
+++ b/desktop_app.py
@@ -219,11 +219,14 @@ class ProcessingPopup:
 
 class PDFExcelDesktopApp:
     def __init__(self):
-        # Configuração da janela principal simples
+        # Configuração da janela principal usando CustomTkinter
         if HAS_DND:
-            self.root = TkinterDnD.Tk()
+            class CTkDnD(ctk.CTk, TkinterDnD.DnDWrapper):
+                """Janela principal com suporte a Drag & Drop"""
+                pass
+            self.root = CTkDnD()
         else:
-            self.root = tk.Tk()
+            self.root = ctk.CTk()
         
         self.root.title("Processamento de Folha de Pagamento v3.2")
         self.root.geometry("950x600")


### PR DESCRIPTION
## Resumo
- Substitui `tk.Tk` por uma janela `CTk` com suporte a Drag & Drop
- Garante compatibilidade com CustomTkinter ao criar janelas secundárias

## Testes
- `python -m py_compile desktop_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68955ef04f2483308fa155341b86324a