### PR TITLE
Corrige inicialização após splash

### DIFF
--- a/desktop_app.py
+++ b/desktop_app.py
@@ -174,9 +174,13 @@ class AppLoader:
         import threading
         load_thread = threading.Thread(target=self._load_main_app, daemon=True)
         load_thread.start()
-        
+
         # Executa loop do splash
         self.splash.root.mainloop()
+
+        # Após fechar o splash, inicia a aplicação principal
+        if self.main_app:
+            self.main_app.run()
     
     def _load_main_app(self):
         """Carrega aplicação principal em background"""
@@ -225,7 +229,7 @@ class AppLoader:
             
             self._update_splash(100, "Concluído!")
             time.sleep(0.2)
-            
+
             # Fecha splash e mostra aplicação principal
             self._show_main_app()
             
@@ -245,12 +249,11 @@ class AppLoader:
             # Fecha splash
             if self.splash:
                 self.splash.close()
-            
+
             # Mostra aplicação principal
             if self.main_app:
                 self.main_app.show()
-                self.main_app.run()
-        
+
         # Executa no thread principal
         if self.splash:
             self.splash.root.after(0, show)


### PR DESCRIPTION
## Resumo
- Ajusta a sequência de inicialização para executar a janela principal após o fechamento do splash
- Remove a chamada ao `run()` durante a exibição do splash

## Testes
- `python -m py_compile desktop_app.py`
- `python desktop_app.py` *(falhou: no display name and no $DISPLAY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_6895d8934a908330b0a2ebc55b72ccb3